### PR TITLE
add Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: all
+
+all: template.pdf
+
+template.pdf: template.tex
+	pdflatex template.tex

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# LaTeX letter
+
+To build, simply run:
+
+```
+make
+```
+
+You might need to install some dependencies. These can be installed with:
+
+```
+sudo tlmgr install lipsum
+```


### PR DESCRIPTION
A Makefile is now included in the project. This means that, to compile the
project, you don't need to do anything other than typing:

```
make
```

Any future additions, such as flags for `pdflatex`, can easily be added to the
Makefile. Super easy.

I've also added a README with instructions on building the project.